### PR TITLE
Potential fix for code scanning alert no. 18: Clear-text logging of sensitive information

### DIFF
--- a/backend/services/gemini_service.py
+++ b/backend/services/gemini_service.py
@@ -91,7 +91,7 @@ class GeminiService:
                     return None
 
             else:
-                logger.error(f"Gemini API request failed with status code {response.status_code}: {response.text}")
+                logger.error(f"Gemini API request failed with status code {response.status_code}")
                 return None
 
         except httpx.ReadTimeout:
@@ -101,7 +101,7 @@ class GeminiService:
             logger.error(f"An error occurred while requesting Gemini API: {e}")
             return None
         except json.JSONDecodeError as e:
-            logger.error(f"Failed to decode JSON from Gemini response: {e}. Response text: {response.text[:200] if 'response' in locals() else 'N/A'}")
+            logger.error(f"Failed to decode JSON from Gemini response: {e}")
             return None
         except Exception as e:
             logger.error(f"An unexpected error occurred in query_gemini_for_raw_json: {e}", exc_info=True)
@@ -301,8 +301,8 @@ def query_gemini_with_audio(audio_path: str, transcript: str, flags: Dict[str, A
             
             return result
         else:
-            logger.error(f"Gemini API error: {response.status_code} - {response.text}")
-            return create_fallback_response(f"Gemini API error: {response.status_code}", response.text)
+            logger.error(f"Gemini API error: {response.status_code}")
+            return create_fallback_response(f"Gemini API error: {response.status_code}", "API error occurred")
             
     except Exception as e:
         logger.error(f"Exception in query_gemini_with_audio: {str(e)}", exc_info=True)
@@ -467,8 +467,8 @@ def query_gemini(transcript: str, flags: Dict[str, Any], session_context: Option
             
             return result
         else:
-            logger.error(f"Gemini API error: {response.status_code} - {response.text}")
-            return create_fallback_response(f"Gemini API error: {response.status_code}", response.text)
+            logger.error(f"Gemini API error: {response.status_code}")
+            return create_fallback_response(f"Gemini API error: {response.status_code}", "API error occurred")
     except Exception as e:
         logger.error(f"Exception in query_gemini: {str(e)}", exc_info=True)
         return create_fallback_response(f"Gemini request error: {str(e)}", str(e))
@@ -935,7 +935,7 @@ def transcribe_with_gemini(audio_path: str) -> str:
             return transcript
             
         else:
-            logger.error(f"Gemini transcription API error: {response.status_code} - {response.text}")
+            logger.error(f"Gemini transcription API error: {response.status_code}")
             raise Exception(f"Gemini transcription API error: {response.status_code}")
             
     except Exception as e:
@@ -1076,7 +1076,7 @@ def analyze_emotions_with_gemini(audio_path: str, transcript: str) -> list:
                 return [{"label": "neutral", "score": 0.6}, {"label": "uncertainty", "score": 0.4}]
             
         else:
-            logger.error(f"Gemini emotion API error: {response.status_code} - {response.text}")
+            logger.error(f"Gemini emotion API error: {response.status_code}")
             return [{"label": "neutral", "score": 0.7}, {"label": "uncertainty", "score": 0.3}]
             
     except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/submit4201/AI-lie-detector-main/security/code-scanning/18](https://github.com/submit4201/AI-lie-detector-main/security/code-scanning/18)

To fix the problem, we should avoid logging the full `response.text` from the Gemini API on error, since it may contain sensitive information. Instead, restrict error logging to the status code and, if necessary, a truncated or sanitized error message, or use only structured error details when possible. 

Specifically, edit the error logging statement on line 1205. Remove (or sanitize) `{response.text}` from the logged string, retaining only the status code. If additional error context is needed, consider logging a generic error or using a safe substring (e.g., first few words) that cannot possibly contain sensitive information.  

No new methods or complex changes are required:  
- Only modify the logger.error statement at line 1205 in `backend/services/gemini_service.py`.
- There are no new imports or dependencies needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Sanitize error handling in the Gemini service by removing clear-text logging of full API response bodies and restricting logged information to HTTP status codes and generic messages.

Bug Fixes:
- Remove logging of full Gemini API response text in error handlers to prevent exposing sensitive data.

Enhancements:
- Restrict error logs to status codes and generic messages across multiple Gemini service methods.
- Replace raw response content in fallback responses with a generic error message.